### PR TITLE
Remove println

### DIFF
--- a/src/main/kotlin/com/glureau/HtmlMermaidDokkaPlugin.kt
+++ b/src/main/kotlin/com/glureau/HtmlMermaidDokkaPlugin.kt
@@ -25,11 +25,10 @@ class HtmlMermaidDokkaPlugin : DokkaPlugin() {
     }
 
     init {
-        println("Mermaid Plugin installed")
+        logger.info("Mermaid Plugin installed")
     }
 
     @DokkaPluginApiPreview
     override fun pluginApiPreviewAcknowledgement(): PluginApiPreviewAcknowledgement =
         PluginApiPreviewAcknowledgement
 }
-


### PR DESCRIPTION
It adds unnecessary noise to the Gradle output when using many modules.